### PR TITLE
Enable Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+rvm:
+  - 1.8.7
+  - 1.9.2
+script: "bundle exec rake test"

--- a/bounce_email.gemspec
+++ b/bounce_email.gemspec
@@ -19,5 +19,9 @@ Gem::Specification.new do |s|
   ["mail"].each do |gem|
     s.add_dependency *gem.split(' ')
   end
+
+  ["rake"].each do |gem|
+    s.add_development_dependency *gem.split(' ')
+  end
 end
 


### PR DESCRIPTION
This PR enables basic Travis CI integration for ruby 1.8.7 and 1.9.2

If once set up, add this to Readme:

``` markdown
## Builder
[![Build Status](https://secure.travis-ci.org/mitio/bounce_email.png)](http://travis-ci.org/mitio/bounce_email)
```
