### PR TITLE
Parse and reassign message-ID, to, from, and subject from original mail

### DIFF
--- a/lib/bounce_email.rb
+++ b/lib/bounce_email.rb
@@ -259,7 +259,7 @@ module BounceEmail
     end
 
     def original_mail_body_lines(mail)
-      @original_mail_body_lines ||= mail.body.to_s.split(/\R+/)
+      @original_mail_body_lines ||= mail.body.to_s.split(/(?:\r\n|\n)+/)
     end
   end
 end

--- a/lib/bounce_email.rb
+++ b/lib/bounce_email.rb
@@ -219,11 +219,13 @@ module BounceEmail
     end
 
     def get_original_mail(mail) #worked alright for me, for sure this has to be extended
+      original =
       if mail.multipart?
         ::Mail.new(mail.parts.last)
       elsif i = index_of_original_message_delimiter(mail)
         ::Mail.new(extract_original_message_after_delimiter(mail, i))
       end
+      extract_and_assign_fields_from_original_mail(original) if original
     rescue => e
       nil
     end
@@ -236,6 +238,39 @@ module BounceEmail
       delimiter = INLINE_MESSAGE_BEGIN_DELIMITERS[delimiter_index]
       message = mail.body.to_s.split(delimiter).last
       message.split(INLINE_MESSAGE_END_DELIMITER).first.strip if message.match(INLINE_MESSAGE_END_DELIMITER)
+    end
+
+    def extract_and_assign_fields_from_original_mail(mail)
+      extract_and_assign_message_id(mail) if mail.message_id.nil?
+      extract_and_assign_from(mail) if mail.from.nil?
+      extract_and_assign_to(mail) if mail.to.nil?
+      extract_and_assign_subject(mail) if mail.subject.nil?
+      mail
+    end
+
+    def extract_and_assign_message_id(mail)
+      value = extract_field(mail, 'Message-ID:')
+      mail.add_message_id(value)
+    end
+
+    def extract_and_assign_to(mail)
+      value = extract_field(mail, 'To:')
+      mail.to = value
+    end
+
+    def extract_and_assign_from(mail)
+      value = extract_field(mail, 'From:')
+      mail.from = value
+    end
+
+    def extract_and_assign_subject(mail)
+      value = extract_field(mail, 'Subject:')
+      mail.subject = value
+    end
+
+    def extract_field(mail, field_name)
+      field = mail.body.to_s.split(/[\n|\r\n]+/).detect { |line| line.match field_name }
+      field.split(':').last.strip if field
     end
   end
 end

--- a/test/bounce_email_test.rb
+++ b/test/bounce_email_test.rb
@@ -113,6 +113,9 @@ class BounceEmailTest < Test::Unit::TestCase
       mail = File.join(File.dirname(__FILE__), 'bounces', "tt_bounce_#{file}.txt")
       bounce = BounceEmail::Mail.new Mail.read(mail)
       assert_not_nil bounce.original_mail
+      assert_not_nil bounce.original_mail.message_id
+      assert_not_nil bounce.original_mail.to
+      assert_not_nil bounce.original_mail.from
     end
   end
 
@@ -127,7 +130,15 @@ class BounceEmailTest < Test::Unit::TestCase
       mail = File.join(File.dirname(__FILE__), 'bounces', "tt_bounce_#{file}.txt")
       bounce = BounceEmail::Mail.new Mail.read(mail)
       assert_not_nil bounce.original_mail
+      assert_not_nil bounce.original_mail.message_id
+      assert_not_nil bounce.original_mail.to
+      assert_not_nil bounce.original_mail.from
     end
+  end
+
+  def test_original_message_with_subject
+    bounce = test_bounce('tt_bounce_04')
+    assert_not_nil bounce.original_mail.subject
   end
 
   private


### PR DESCRIPTION
Sometimes it may be useful to access fields from the original mail in order to track/update the state of sent mail. These methods work to rebuild the original mail to the Mail object format as much as possible.