### PR TITLE
Replaced 'X-Original-To' header with 'X-Failed-Recipients'.

### DIFF
--- a/lib/bounce_email.rb
+++ b/lib/bounce_email.rb
@@ -247,14 +247,17 @@ module BounceEmail
       end
 
       original.from ||= extract_field_from(original, /^From:/)
-      original.to ||= (extract_original_to_field_from(bounce) || extract_field_from(original, /^To:/))
+
+      original.to ||= (extract_original_to_field_from_header(bounce) ||
+                       extract_field_from(original, /^To:/))
+
       original.subject ||= extract_field_from(original, /^Subject:/)
 
       original
     end
 
-    def extract_original_to_field_from(mail)
-      header = mail.header["X-Original-To"]
+    def extract_original_to_field_from_header(mail)
+      header = mail.header["X-Failed-Recipients"]
       header.value if header && header.value
     end
 


### PR DESCRIPTION
- 'X-Original-To' seems to be used for VERP, whereas
  'X-Failed-Recipients' seems to be used solely as a reference regarding
  the original failed recipient.
- Fixes https://github.com/livebg/bounce_email/issues/9