### PR TITLE
fix original email parsing

### DIFF
--- a/lib/bounce_email.rb
+++ b/lib/bounce_email.rb
@@ -221,7 +221,7 @@ module BounceEmail
     def get_original_mail(mail) #worked alright for me, for sure this has to be extended
       original =
         if mail.multipart?
-          ::Mail.new(mail.parts.last)
+          ::Mail.new(mail.parts.last.body)
         elsif i = index_of_original_message_delimiter(mail)
           ::Mail.new(extract_original_message_after_delimiter(mail, i))
         end
@@ -242,19 +242,7 @@ module BounceEmail
     end
 
     def extract_and_assign_fields_from(bounce, original)
-      if original.message_id.nil?
-        original.add_message_id extract_field_from(original, /^Message-ID:/)
-      end
-
-      original.from ||= extract_field_from(original, /^From:/)
-
-      original.to ||= (extract_original_to_field_from_header(bounce) ||
-                       extract_field_from(original, /^To:/))
-
-      original.subject ||= extract_field_from(original, /^Subject:/)
-
-      original.date ||= extract_field_from(original, /^Date:/)
-
+      original.to ||= extract_original_to_field_from_header(bounce)
       original
     end
 


### PR DESCRIPTION
Original email parsing was broken when original contained in multipart .

Was using mail.parts.last for original mail when mutli-part which includes Content-Type header for message part and the body is the actual original message.

This was causing original mail to be created with Content-Type as only header and failing to set/parse all the actual message headers. This message parse failure led to manually setting from, to, subject, date.

Now, using  mail.parts.last.**body** as the original_mail and all regular header parsing is working. no need to do manual setting of from, to, subject, date fields